### PR TITLE
Reading network from config file.

### DIFF
--- a/Mural/App.config
+++ b/Mural/App.config
@@ -2,6 +2,7 @@
 <configuration>
 	<configSections>
 		<section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+		<section name="hosts" type="Mural.PortConfigurationSection, Mural"/>
 	</configSections>
 
 	<log4net>
@@ -16,4 +17,14 @@
 			<appender-ref ref="MuralConsole" />
 		</root>
 	</log4net>
+	<hosts>
+		<host name="localhost">
+			<port number="8080" type="telnet" /> 
+		</host>
+		<host name="remotehost">
+			<port number="80" type="http" />
+			<port number="8080" type="telnet" />
+			<port number="8080" type="ssh" />
+		</host>
+	</hosts>
 </configuration>

--- a/Mural/App.config
+++ b/Mural/App.config
@@ -21,9 +21,5 @@
 		<host name="localhost">
 			<port number="8080" type="telnet" /> 
 		</host>
-		<host name="remotehost">
-			<port number="80" type="http" />
-			<port number="80" type="telnet" />
-		</host>
 	</hosts>
 </configuration>

--- a/Mural/App.config
+++ b/Mural/App.config
@@ -18,7 +18,7 @@
 		</root>
 	</log4net>
 	<hosts>
-		<host name="localhost">
+		<host name="127.0.0.1">
 			<port number="8080" type="telnet" /> 
 		</host>
 	</hosts>

--- a/Mural/App.config
+++ b/Mural/App.config
@@ -23,8 +23,7 @@
 		</host>
 		<host name="remotehost">
 			<port number="80" type="http" />
-			<port number="8080" type="telnet" />
-			<port number="8080" type="ssh" />
+			<port number="80" type="telnet" />
 		</host>
 	</hosts>
 </configuration>

--- a/Mural/HostElement.cs
+++ b/Mural/HostElement.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Configuration;
+
+namespace Mural
+{
+	public class HostElement : ConfigurationElement
+	{
+		[ConfigurationProperty("name")]
+		public String Name
+		{
+			get
+			{
+				return (String)this["name"];
+			}
+		}
+		
+		[ConfigurationProperty("", IsDefaultCollection = true)]
+		public PortElementCollection PortCollection
+		{
+			get
+			{
+				return (PortElementCollection)this[""];
+			}
+		}
+		
+		// TODO: Uncomment this once we're done debugging.
+/*		public PortElement this [int number]
+		{
+			get {
+				return (PortElement)BaseGet(number);
+			}
+		} */
+	}
+
+}
+

--- a/Mural/HostElement.cs
+++ b/Mural/HostElement.cs
@@ -3,8 +3,14 @@ using System.Configuration;
 
 namespace Mural
 {
+	// This is the definition for a single host element.
+	// In the XML, it looks like:
+	//   <host name="foo">
+	//     ...
+	//   </host>
 	public class HostElement : ConfigurationElement
 	{
+		// This is pulling the name property
 		[ConfigurationProperty("name")]
 		public String Name
 		{
@@ -14,6 +20,11 @@ namespace Mural
 			}
 		}
 		
+		// So, ConfigurationProperty is a decorator to indicate some property of this XML element.
+		// In this case, though, the combination of "" as the name and IsDefaultCollection actually means
+		//  that we're taking the set of all subtags within this element.
+		// (The set of <port> tags, in this case.)
+		// They correspond to our PortElementCollection class.
 		[ConfigurationProperty("", IsDefaultCollection = true)]
 		public PortElementCollection PortCollection
 		{

--- a/Mural/HostElement.cs
+++ b/Mural/HostElement.cs
@@ -33,14 +33,6 @@ namespace Mural
 				return (PortElementCollection)this[""];
 			}
 		}
-		
-		// TODO: Uncomment this once we're done debugging.
-/*		public PortElement this [int number]
-		{
-			get {
-				return (PortElement)BaseGet(number);
-			}
-		} */
 	}
 
 }

--- a/Mural/HostElementCollection.cs
+++ b/Mural/HostElementCollection.cs
@@ -24,14 +24,14 @@ namespace Mural
 		{
 			return ((HostElement)element).Name;
 		}
-		// TODO: Uncomment this once we're done debugging.
-/*  	new public HostElement this [String name]
+		
+		new public HostElement this [String name]
 		{
 			get {
 				return (HostElement)BaseGet(name);
 			}
 		}
-		*/
+		
 	}
 }
 

--- a/Mural/HostElementCollection.cs
+++ b/Mural/HostElementCollection.cs
@@ -3,20 +3,29 @@ using System.Configuration;
 
 namespace Mural
 {
+	// This is a collection of multiple ConfigurationElements.
+	// The decorator here tells us that, in case we missed the subclassing.
+	// Additionally, it says that:
+	//  - The elements contained in this collection are of type HostElement
+	//  - The tag in the XML we should recognize as an element to add is "host"
 	[ConfigurationCollection(typeof(HostElement), AddItemName = "host")]
 	public class HostElementCollection : ConfigurationElementCollection
 	{
+		// When we make a new element, make it a HostElement! This gets called automagically.
 		protected override System.Configuration.ConfigurationElement CreateNewElement()
 		{
 			return new HostElement();
 		}
 		
+		// This is where we define what the unique key for this collection is. In this case, it's the name.
+		// Two hosts cannot have the same hostname.
+		// If they do in the XML, the parser will throw an exception when it discovers that.
 		protected override object GetElementKey(System.Configuration.ConfigurationElement element) 
 		{
 			return ((HostElement)element).Name;
 		}
 		// TODO: Uncomment this once we're done debugging.
-/*		new public HostElement this [String name]
+/*  	new public HostElement this [String name]
 		{
 			get {
 				return (HostElement)BaseGet(name);

--- a/Mural/HostElementCollection.cs
+++ b/Mural/HostElementCollection.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Configuration;
+
+namespace Mural
+{
+	[ConfigurationCollection(typeof(HostElement), AddItemName = "host")]
+	public class HostElementCollection : ConfigurationElementCollection
+	{
+		protected override System.Configuration.ConfigurationElement CreateNewElement()
+		{
+			return new HostElement();
+		}
+		
+		protected override object GetElementKey(System.Configuration.ConfigurationElement element) 
+		{
+			return ((HostElement)element).Name;
+		}
+		// TODO: Uncomment this once we're done debugging.
+/*		new public HostElement this [String name]
+		{
+			get {
+				return (HostElement)BaseGet(name);
+			}
+		}
+		*/
+	}
+}
+

--- a/Mural/ListenerConfiguration.cs
+++ b/Mural/ListenerConfiguration.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Mural
+{
+	public class ListenerConfiguration
+	{
+		// TODO: Getter/Setter, validation.
+		public String host;
+		
+		// TODO: Getter/Setter, validation.
+		public int port;
+		
+		// TODO: Getter/Setter, validation.
+		public String type;
+			
+		public ListenerConfiguration ()
+		{
+			
+		}
+		
+		public ListenerConfiguration (String host, int port, String type)
+		{
+			this.host = host;
+			this.port = port;
+			this.type = type;
+		}
+	}
+}
+

--- a/Mural/ListenerConfiguration.cs
+++ b/Mural/ListenerConfiguration.cs
@@ -4,14 +4,23 @@ namespace Mural
 {
 	public class ListenerConfiguration
 	{
-		// TODO: Getter/Setter, validation.
-		public String host;
+		public String Host
+		{
+			get;
+			private set;
+		}
 		
-		// TODO: Getter/Setter, validation.
-		public int port;
+		public int Port
+		{
+			get;
+			private set;
+		}
 		
-		// TODO: Getter/Setter, validation.
-		public String type;
+		public String Type
+		{
+			get;
+			private set;
+		}
 			
 		public ListenerConfiguration ()
 		{
@@ -20,9 +29,9 @@ namespace Mural
 		
 		public ListenerConfiguration (String host, int port, String type)
 		{
-			this.host = host;
-			this.port = port;
-			this.type = type;
+			this.Host = host;
+			this.Port = port;
+			this.Type = type;
 		}
 	}
 }

--- a/Mural/ListenerConfiguration.cs
+++ b/Mural/ListenerConfiguration.cs
@@ -2,8 +2,20 @@ using System;
 
 namespace Mural
 {
+	/// ListenerConfiguration holds the data required to set up a single Listener of some type:
+	///   - a hostname, a port, and a connection type (telnet, ssl, http, etc.)
 	public class ListenerConfiguration
 	{
+		public ListenerConfiguration ()
+		{
+		}
+		
+		public ListenerConfiguration (String host, int port, String type)
+		{
+			this.Host = host;
+			this.Port = port;
+			this.Type = type;
+		}
 		public String Host
 		{
 			get;
@@ -21,18 +33,6 @@ namespace Mural
 			get;
 			private set;
 		}
-			
-		public ListenerConfiguration ()
-		{
-			
-		}
-		
-		public ListenerConfiguration (String host, int port, String type)
-		{
-			this.Host = host;
-			this.Port = port;
-			this.Type = type;
-		}
-	}
+	}			
 }
 

--- a/Mural/Main.cs
+++ b/Mural/Main.cs
@@ -73,7 +73,7 @@ namespace Mural
 			// Right now, this foreach is abusing the fact that the StartListenerLoop on a TelnetListener doesn't return.
 			// It will keep trying until it finds one of type telnet, then pause there. Forever.
 			foreach(ListenerConfiguration config in connectionList) {
-				IPHostEntry ipHostInfo = Dns.GetHostEntry(config.host);
+				IPHostEntry ipHostInfo = Dns.GetHostEntry(config.Host);
 				
 				// Gets the IP Address associated with the host given.
 				// Assuming that it was an actual IP Address, there should only be one.
@@ -82,14 +82,14 @@ namespace Mural
 				IPAddress ipAddress = ipHostInfo.AddressList[0];
 				
 				_log.DebugFormat("Using net configuration: {0}:{1} ({2}). Listener type: {3}", 
-					config.host, config.port, ipAddress.ToString(), config.type);
+					config.Host, config.Port, ipAddress.ToString(), config.Type);
 				
 				ILineConsumer defaultParser = new LoginParser(); //new RedirectingParser();
 				
 				// TODO: Make connection type an enum so this can be a switch statement.
 				// Or, possibly, a different refactor as part of making this support multiple listeners.
-				if(((String)config.type).Equals("telnet")) {
-					TelnetListener telnetListener = new TelnetListener(defaultParser, ipAddress, config.port);
+				if(((String)config.Type).Equals("telnet")) {
+					TelnetListener telnetListener = new TelnetListener(defaultParser, ipAddress, config.Port);
 					// TODO: What does it look like to end the program politely? 
 					// Who handles that, and how do we terminate the listener loops?
 					// Do we support connection-draining?

--- a/Mural/Main.cs
+++ b/Mural/Main.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using log4net;
 using log4net.Config;
+using System.Configuration;
 
 namespace Mural
 {
@@ -23,6 +24,9 @@ namespace Mural
 			
 			// TODO: Figure out how Mural actually becomes aware of the IP addresses it serves,
 			// and the ports it should listen on. Perhaps the standard .NET .config XML files?
+						
+			// TODO: This will cause a ConfigurationException for a duplicate host or port number. Catch and log!
+			PortConfigurationSection PortConfig = (PortConfigurationSection)System.Configuration.ConfigurationManager.GetSection("hosts");				
 			
 			// This whole next bit is hackish: It gets an IP address (probably!) that _should_ work for this machine.
 			// No promises are made that it does or it will. It is certain to fail miserably on machines that host

--- a/Mural/Main.cs
+++ b/Mural/Main.cs
@@ -22,12 +22,19 @@ namespace Mural
 			// TODO: Replace the logic here that connects components with an IoC system.
 			// Probably use Ninject for this purpose: http://ninject.org/
 			
-			// TODO: Figure out how Mural actually becomes aware of the IP addresses it serves,
-			// and the ports it should listen on. Perhaps the standard .NET .config XML files?
-			
-			// Pull values for Port Configuration as defined in App.config
+			// This is a list, to be populated with all the host/ports we know about.
+			// Is ArrayList the right type here?
+			System.Collections.ArrayList connectionList = new System.Collections.ArrayList();
 			try {
+				// Pull values for Port Configuration as defined in App.config
 				PortConfigurationSection PortConfig = (PortConfigurationSection)ConfigurationManager.GetSection("hosts");
+				
+				foreach(HostElement host in PortConfig.HostCollection) {
+					foreach(PortElement port in host.PortCollection) {
+						// ListenerConfiguration is essentially a struct with name, number, and type.
+						connectionList.Add(new ListenerConfiguration(host.Name, port.Number, port.Type));
+					}
+				}
 			} catch(ConfigurationException e) {
 				// This will cause a ConfigurationException for a duplicate host or port number.
 				// There may be other error conditions that cause ConfigurationExceptions.
@@ -36,33 +43,59 @@ namespace Mural
 				_log.ErrorFormat(e.Message);
 				Environment.Exit(1);
 			}
-			// This whole next bit is hackish: It gets an IP address (probably!) that _should_ work for this machine.
-			// No promises are made that it does or it will. It is certain to fail miserably on machines that host
-			//  multiple domains, or have multiple IP addresses, or are behind load balancers, or are interesting in any
-			//  of a number of other ways. It has fascinating issues on WinBoxen with IPv6 installed.
-			// That is to say:
-			// THIS IS NOT PRODUCTION CODE.
-			// Replace this with a combination of defaulting as elegantly as possible to let simple users get it
-			//  mostly-right when they try to run Mural on their local boxen, and reading from config files so that
-			//  serious installers of Mural can set it all up in config and have it work.
-			String localHostName = Dns.GetHostName();
 			
-			localHostName = "localhost";
+			if(connectionList.Count == 0) {
+				// There was nothing in the XML for connections!
+				// TODO: A fancy configuration step.
+				
+				// If there was nothing at all, we're defaulting to a hackish way of getting something, anything.
+				// We do this by making a ListenerConfiguration for localhost on port 8888, and then proceeding normally.
+				// In a simply case, this should work. HOWEVER!
+				// Using these parameters will get an IP address (probably!) that _should_ work for this machine.
+				// No promises are made that it does or it will. It is certain to fail miserably on machines that host
+				//  multiple domains, or have multiple IP addresses, or are behind load balancers, or are interesting in any
+				//  of a number of other ways. It has fascinating issues on WinBoxen with IPv6 installed.
+				// Failure is highly possible; we may want to simply exit if we encounter this condition,
+				//  or have more elaborate code in place to handle it.
+				// This is, however, a form of defaulting to let simple users get it mostly-right when they try to 
+				//  run Mural on their local boxen
+				// Serious installers of Mural can set it all up in config and have it work.
+	
+				connectionList.Add(new ListenerConfiguration("localhost", 8888, "telnet"));
+			}
 			
-			IPHostEntry ipHostInfo = Dns.GetHostEntry(localHostName);
-			// Gets the first IP Address associated with this machine.
-			IPAddress ipAddress = ipHostInfo.AddressList[0];
-			int port = 8888;
 			
-			_log.DebugFormat("Autodetected net configuration: {0} ({1})", localHostName, ipAddress.ToString());
-			
-			ILineConsumer defaultParser = new LoginParser(); //new RedirectingParser();
-			
-			TelnetListener telnetListener = new TelnetListener(defaultParser, ipAddress, port);
-			// TODO: What does it look like to end the program politely? 
-			// Who handles that, and how do we terminate the listener loops?
-			// Do we support connection-draining?
-			telnetListener.StartListenerLoop(); // This method doesn't return under normal circumstances.
+			// We currently do not have the architecture in place to launch multiple listeners.
+			// Therefore, we are going to use whatever the first item in the connectionList.
+			// TODO: Support multiple listeners.
+			// Once we have the architectural support for multiple listeners, we'll want to iterate 
+			//  through the connectionList and set them all up.
+			// Right now, this foreach is abusing the fact that the StartListenerLoop on a TelnetListener doesn't return.
+			// It will keep trying until it finds one of type telnet, then pause there. Forever.
+			foreach(ListenerConfiguration config in connectionList) {
+				IPHostEntry ipHostInfo = Dns.GetHostEntry(config.host);
+				
+				// Gets the IP Address associated with the host given.
+				// Assuming that it was an actual IP Address, there should only be one.
+				// If it was a hostname, there might be several. We take the first; if something else is needed,
+				//  then it should have been specified in the config file. That's what it's there for.
+				IPAddress ipAddress = ipHostInfo.AddressList[0];
+				
+				_log.DebugFormat("Using net configuration: {0}:{1} ({2}). Listener type: {3}", 
+					config.host, config.port, ipAddress.ToString(), config.type);
+				
+				ILineConsumer defaultParser = new LoginParser(); //new RedirectingParser();
+				
+				// TODO: Make connection type an enum so this can be a switch statement.
+				// Or, possibly, a different refactor as part of making this support multiple listeners.
+				if(((String)config.type).Equals("telnet")) {
+					TelnetListener telnetListener = new TelnetListener(defaultParser, ipAddress, config.port);
+					// TODO: What does it look like to end the program politely? 
+					// Who handles that, and how do we terminate the listener loops?
+					// Do we support connection-draining?
+					telnetListener.StartListenerLoop(); // This method doesn't return under normal circumstances.
+				}
+			}
 			
 			_log.Debug("Reached the end of the program.");
 		}

--- a/Mural/Main.cs
+++ b/Mural/Main.cs
@@ -24,10 +24,18 @@ namespace Mural
 			
 			// TODO: Figure out how Mural actually becomes aware of the IP addresses it serves,
 			// and the ports it should listen on. Perhaps the standard .NET .config XML files?
-						
-			// TODO: This will cause a ConfigurationException for a duplicate host or port number. Catch and log!
-			PortConfigurationSection PortConfig = (PortConfigurationSection)System.Configuration.ConfigurationManager.GetSection("hosts");				
 			
+			// Pull values for Port Configuration as defined in App.config
+			try {
+				PortConfigurationSection PortConfig = (PortConfigurationSection)ConfigurationManager.GetSection("hosts");
+			} catch(ConfigurationException e) {
+				// This will cause a ConfigurationException for a duplicate host or port number.
+				// There may be other error conditions that cause ConfigurationExceptions.
+				// Regardless, if we can't read our configuration, we are sad and confused pandas.
+				// Log as an error, then exit.
+				_log.ErrorFormat(e.Message);
+				Environment.Exit(1);
+			}
 			// This whole next bit is hackish: It gets an IP address (probably!) that _should_ work for this machine.
 			// No promises are made that it does or it will. It is certain to fail miserably on machines that host
 			//  multiple domains, or have multiple IP addresses, or are behind load balancers, or are interesting in any

--- a/Mural/Main.cs
+++ b/Mural/Main.cs
@@ -48,20 +48,8 @@ namespace Mural
 				// There was nothing in the XML for connections!
 				// TODO: A fancy configuration step.
 				
-				// If there was nothing at all, we're defaulting to a hackish way of getting something, anything.
-				// We do this by making a ListenerConfiguration for localhost on port 8888, and then proceeding normally.
-				// In a simply case, this should work. HOWEVER!
-				// Using these parameters will get an IP address (probably!) that _should_ work for this machine.
-				// No promises are made that it does or it will. It is certain to fail miserably on machines that host
-				//  multiple domains, or have multiple IP addresses, or are behind load balancers, or are interesting in any
-				//  of a number of other ways. It has fascinating issues on WinBoxen with IPv6 installed.
-				// Failure is highly possible; we may want to simply exit if we encounter this condition,
-				//  or have more elaborate code in place to handle it.
-				// This is, however, a form of defaulting to let simple users get it mostly-right when they try to 
-				//  run Mural on their local boxen
-				// Serious installers of Mural can set it all up in config and have it work.
-	
-				connectionList.Add(new ListenerConfiguration("localhost", 8888, "telnet"));
+				_log.Warn("No configuration provided! Please provide one in App.config");
+				Environment.Exit(0);
 			}
 			
 			
@@ -88,12 +76,18 @@ namespace Mural
 				
 				// TODO: Make connection type an enum so this can be a switch statement.
 				// Or, possibly, a different refactor as part of making this support multiple listeners.
-				if(((String)config.Type).Equals("telnet")) {
+				switch(config.Type) 
+				{
+				case "telnet" :
 					TelnetListener telnetListener = new TelnetListener(defaultParser, ipAddress, config.Port);
 					// TODO: What does it look like to end the program politely? 
 					// Who handles that, and how do we terminate the listener loops?
 					// Do we support connection-draining?
 					telnetListener.StartListenerLoop(); // This method doesn't return under normal circumstances.
+					break;
+				default:
+					_log.Warn(String.Format("No listener of type {0}.", config.Type));
+					break;
 				}
 			}
 			

--- a/Mural/Mural.csproj
+++ b/Mural/Mural.csproj
@@ -83,6 +83,7 @@
     <Compile Include="PortElementCollection.cs" />
     <Compile Include="PortElement.cs" />
     <Compile Include="PortConfigurationSection.cs" />
+    <Compile Include="ListenerConfiguration.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Mural/Mural.csproj
+++ b/Mural/Mural.csproj
@@ -38,6 +38,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Lib\log4net\log4net-1.2.10\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Main.cs" />
@@ -77,6 +78,11 @@
     <Compile Include="RequestDisconnectEventArgs.cs" />
     <Compile Include="ResponseLineEventArgs.cs" />
     <Compile Include="BasicLineConsumer.cs" />
+    <Compile Include="HostElementCollection.cs" />
+    <Compile Include="HostElement.cs" />
+    <Compile Include="PortElementCollection.cs" />
+    <Compile Include="PortElement.cs" />
+    <Compile Include="PortConfigurationSection.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Mural/PortConfigurationSection.cs
+++ b/Mural/PortConfigurationSection.cs
@@ -6,6 +6,7 @@ namespace Mural
 	// The ConfigurationSection corresponds to a blob of XML in the App.config.
 	// It is registered in the configsections, and used to parse that part of the XML.
 	// PortConfigurationSection is what we use to store the hostnames and ports being used by Mural.
+	// TODO: Set up the config system to be writable for a web-based configuration tool.
 	public class PortConfigurationSection : ConfigurationSection
 	{
 		// So, ConfigurationProperty is a decorator to indicate some property of this XML element.
@@ -21,7 +22,6 @@ namespace Mural
 			{
 				return (HostElementCollection)this[""];
 			}
-			// TODO: write a setter for automated config.
 		}
 	}
 }

--- a/Mural/PortConfigurationSection.cs
+++ b/Mural/PortConfigurationSection.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Configuration;
+
+namespace Mural
+{
+	public class PortConfigurationSection : ConfigurationSection
+	{
+		[ConfigurationProperty("", IsDefaultCollection = true)]
+		public HostElementCollection HostCollection
+		{
+			get
+			{
+				return (HostElementCollection)this[""];
+			}
+		}
+	}
+}

--- a/Mural/PortConfigurationSection.cs
+++ b/Mural/PortConfigurationSection.cs
@@ -7,6 +7,7 @@ namespace Mural
 	// It is registered in the configsections, and used to parse that part of the XML.
 	// PortConfigurationSection is what we use to store the hostnames and ports being used by Mural.
 	// TODO: Set up the config system to be writable for a web-based configuration tool.
+	// TODO: Validation for the config elements.
 	public class PortConfigurationSection : ConfigurationSection
 	{
 		// So, ConfigurationProperty is a decorator to indicate some property of this XML element.

--- a/Mural/PortConfigurationSection.cs
+++ b/Mural/PortConfigurationSection.cs
@@ -3,15 +3,25 @@ using System.Configuration;
 
 namespace Mural
 {
+	// The ConfigurationSection corresponds to a blob of XML in the App.config.
+	// It is registered in the configsections, and used to parse that part of the XML.
+	// PortConfigurationSection is what we use to store the hostnames and ports being used by Mural.
 	public class PortConfigurationSection : ConfigurationSection
 	{
+		// So, ConfigurationProperty is a decorator to indicate some property of this XML element.
+		// In this case, though, the combination of "" as the name and IsDefaultCollection actually means
+		//  that we're taking the set of all subtags within this element.
+		// (The set of <host> tags, in this case.)
+		// They correspond to our HostElementCollection class.
 		[ConfigurationProperty("", IsDefaultCollection = true)]
 		public HostElementCollection HostCollection
 		{
+			// The getter for our collection of tags.
 			get
 			{
 				return (HostElementCollection)this[""];
 			}
+			// TODO: write a setter for automated config.
 		}
 	}
 }

--- a/Mural/PortElement.cs
+++ b/Mural/PortElement.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Configuration;
+
+namespace Mural
+{
+	public class PortElement : ConfigurationElement
+	{
+		[ConfigurationProperty("number")]
+		public int Number
+		{
+			get
+			{
+				return (int)this["number"];
+			}
+		}
+		
+		[ConfigurationProperty("type")]
+		public String Type
+		{
+			get
+			{
+				return (String)this["type"];
+			}
+		}
+		
+	}
+
+}
+

--- a/Mural/PortElement.cs
+++ b/Mural/PortElement.cs
@@ -27,7 +27,8 @@ namespace Mural
 		//   SSH
 		//   ...Jabber? SMTP? etc.
 		// For now, it's just a string.
-		[ConfigurationProperty("type")]
+		// If we don't have a type listed, we assume telnet.
+		[ConfigurationProperty("type", DefaultValue = "telnet")]
 		public String Type
 		{
 			get

--- a/Mural/PortElement.cs
+++ b/Mural/PortElement.cs
@@ -3,8 +3,12 @@ using System.Configuration;
 
 namespace Mural
 {
+	// This is the definition for a single port element.
+	// In the XML, it looks like:
+	//   <port number="1234" type="foo" />
 	public class PortElement : ConfigurationElement
 	{
+		// A port has a number property...
 		[ConfigurationProperty("number")]
 		public int Number
 		{
@@ -14,6 +18,15 @@ namespace Mural
 			}
 		}
 		
+		// ...and a type property.
+		// TODO: Validation. This can only support a limited set of types.
+		// We probably want an enum here.
+		// It can be:
+		//   HTTP
+		//   Telnet
+		//   SSH
+		//   ...Jabber? SMTP? etc.
+		// For now, it's just a string.
 		[ConfigurationProperty("type")]
 		public String Type
 		{

--- a/Mural/PortElementCollection.cs
+++ b/Mural/PortElementCollection.cs
@@ -3,15 +3,24 @@ using System.Configuration;
 
 namespace Mural
 {
-	// TODO: KIll this. ... or not?
+	// This is a collection of multiple ConfigurationElements.
+	// The decorator here tells us that, in case we missed the subclassing.
+	// Additionally, it says that:
+	//  - The elements contained in this collection are of type PortElement
+	//  - The tag in the XML we should recognize as an element to add is "port"
 	[ConfigurationCollection(typeof(PortElement), AddItemName = "port")]
 	public class PortElementCollection : ConfigurationElementCollection
 	{
+		// When we make a new element, make it a PortElement! This gets called automagically.
 		protected override System.Configuration.ConfigurationElement CreateNewElement()
 		{
 			return new PortElement();
 		}
 		
+		// This is where we define what the unique key for this collection is. In this case, it's the number.
+		// Two ports cannot have the same number.
+		// If they do in the XML, the parser will throw an exception when it discovers that.
+		// Of course, ports are only required to be unique within the containing hostname, not globally.
 		protected override object GetElementKey(System.Configuration.ConfigurationElement element) 
 		{
 			return ((PortElement)element).Number;

--- a/Mural/PortElementCollection.cs
+++ b/Mural/PortElementCollection.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Configuration;
+
+namespace Mural
+{
+	// TODO: KIll this. ... or not?
+	[ConfigurationCollection(typeof(PortElement), AddItemName = "port")]
+	public class PortElementCollection : ConfigurationElementCollection
+	{
+		protected override System.Configuration.ConfigurationElement CreateNewElement()
+		{
+			return new PortElement();
+		}
+		
+		protected override object GetElementKey(System.Configuration.ConfigurationElement element) 
+		{
+			return ((PortElement)element).Number;
+		}
+	}
+
+}
+


### PR DESCRIPTION
Host/port is read from the config file. If it is not present there, the system logs a warning and does not start.

While the config file supports multiple hosts, ports, and types of connections, the architecture of the codebase currently does not. It will cheerfully read them, but it only creates a single connection, on the first telnet host/port listed. All others are ignored.
